### PR TITLE
Skin Name Configuration

### DIFF
--- a/DSPlus.lua
+++ b/DSPlus.lua
@@ -16,21 +16,21 @@ local usable_path = mod_path:match("Mods/[^/]+")
 sendDebugMessage("Mod Path: " .. usable_path)
 
 function recursiveEnumerate(folder)
-	local fileTree = ""
-	for _, file in ipairs(love.filesystem.getDirectoryItems(folder)) do
-		local path = folder .. "/" .. file
-		local info = love.filesystem.getInfo(path)
-		fileTree = fileTree .. "\n" .. path .. (info.type == "directory" and " (DIR)" or "")
-		if info.type == "directory" then
-			fileTree = fileTree .. recursiveEnumerate(path)
-		end
-	end
-	return fileTree
+    local fileTree = ""
+    for _, file in ipairs(love.filesystem.getDirectoryItems(folder)) do
+        local path = folder .. "/" .. file
+        local info = love.filesystem.getInfo(path)
+        fileTree = fileTree .. "\n" .. path .. (info.type == "directory" and " (DIR)" or "")
+        if info.type == "directory" then
+            fileTree = fileTree .. recursiveEnumerate(path)
+        end
+    end
+    return fileTree
 end
 
 local files = {}
 for s in recursiveEnumerate(usable_path .. "/skins"):gmatch("[^\r\n]+") do
-	files[#files + 1] = s:gsub(usable_path .. "/skins/", "")
+    files[#files + 1] = s:gsub(usable_path .. "/skins/", "")
 end
 sendDebugMessage(tprint(files))
 
@@ -38,88 +38,113 @@ sendDebugMessage(tprint(files))
 --- Load Skins ---
 ------------------
 local loadCounts = {
-	Hearts = 0,
-	Clubs = 0,
-	Diamonds = 0,
-	Spades = 0
+    Hearts = 0,
+    Clubs = 0,
+    Diamonds = 0,
+    Spades = 0
 }
+
 local suits = {
-	Hearts = "H",
-	Clubs = "C",
-	Diamonds = "D",
-	Spades = "S"
+	Hearts = {"Hearts", "hearts", "H", "h"},
+	Clubs = {"Clubs", "clubs", "C", "c"},
+	Diamonds = {"Diamonds", "diamonds", "D", "d"},
+	Spades = {"Spades", "spades", "S", "s"}
 }
 
 G.EXTRA_SKINS, G.EXTRA_SKINS_NAMES = {}, {}
 for suit in pairs(suits) do
-	G.EXTRA_SKINS[suit], G.EXTRA_SKINS_NAMES[suit] = {}, {}
+    G.EXTRA_SKINS[suit], G.EXTRA_SKINS_NAMES[suit] = {}, {}
 end
 
+local function suitMatches(skinSuit, suitAliases)
+    for _, alias in ipairs(suitAliases) do
+        if skinSuit:lower() == alias:lower() then
+            return true
+        end
+    end
+end
+
+local function getSkinName(skin, suit)
+	if type(skin.name) == "string" then
+		return skin.name
+	end
+
+	if type(skin.name) == "table" then
+		local aliases = suits[suit]
+		for _, alias in ipairs(aliases) do
+			if skin.name[alias] then
+				return skin.name[alias]
+			end
+		end
+	end
+end
+
+
 local function loadSkin(skin, id, suit, cards)
+	local skinName = getSkinName(skin, suit)
+	if not skinName then
+		return
+	end
+
 	G.COLLABS.options[suit][id] = cards
 	G.COLLABS.list[suit][#G.COLLABS.list[suit] + 1] = id
 	loadCounts[suit] = loadCounts[suit] + 1
 	G.EXTRA_SKINS[suit][loadCounts[suit]] = id
-	G.EXTRA_SKINS_NAMES[suit][loadCounts[suit]] = skin.name
+	G.EXTRA_SKINS_NAMES[suit][loadCounts[suit]] = skinName
 	sendDebugMessage(tprint(G.EXTRA_SKINS_NAMES[suit]))
 end
 
 for _, file in ipairs(files) do
-	sendDebugMessage(file .. " found!")
+    sendDebugMessage(file .. " found!")
 
-	if file:match("%.lua$") then
-		local skin = SMODS.load_file("skins/" .. file)()
-		local id = file:sub(1, -5)
+    if file:match("%.lua$") then
+        local skin = SMODS.load_file("skins/" .. file)()
+        local id = file:sub(1, -5)
 
-		sendDebugMessage(file .. " loaded as " .. id)
+        sendDebugMessage(file .. " loaded as " .. id)
 
-		local defaultCards = {"2", "3", "4", "5", "6", "7", "8", "9", "10", "Jack", "Queen", "King", "Ace"}
-		local cardShorts = {
-			J = "Jack",
-			Q = "Queen",
-			K = "King",
-			A = "Ace"
-		}
+        local defaultCards = { "2", "3", "4", "5", "6", "7", "8", "9", "10", "Jack", "Queen", "King", "Ace" }
+        local cardShorts = { J = "Jack", Q = "Queen", K = "King", A = "Ace" }
 
-		local cards = skin.cards or defaultCards
-		for i, card in ipairs(cards) do
-			local normalized = card:lower():gsub("^%l", string.upper)
-			cards[i] = cardShorts[card:sub(1, 1)] or normalized
-		end
+        local cards = skin.cards or defaultCards
+        for i, card in ipairs(cards) do
+            local normalized = card:lower():gsub("^%l", string.upper)
+            cards[i] = cardShorts[card:sub(1, 1)] or normalized
+        end
 
-		local allSuits = skin.suit:lower() == "all" or skin.suit:lower() == "a" or skin.suit == "*"
-		for suit, short in pairs(suits) do
-			if allSuits or skin.suit:lower() == short:lower() or skin.suit:lower() == suit:lower() then
-				loadSkin(skin, id, suit, cards)
+        local allSuits = skin.suit:lower() == "all" or skin.suit:lower() == "a" or skin.suit == "*"
+        for suit, aliases in pairs(suits) do
+            if allSuits or suitMatches(skin.suit, aliases) then
+                loadSkin(skin, id, suit, cards)
 
 				if allSuits then
 					G.COLLABS.options[suit][id].ALL_SUITS = true
 				end
-			end
-		end
+            end
+        end
 
-		local texture1, texture2 = skin.texture, skin.highContrastTexture or skin.texture
-		SMODS.Atlas {
-			key = id .. "_1",
-			path = texture1,
-			px = 71,
-			py = 95,
-			atlas_table = 'ASSET_ATLAS',
-			prefix_config = {
+        local texture1, texture2 = skin.texture, skin.highContrastTexture or skin.texture
+        SMODS.Atlas {
+            key = id .. "_1",
+            path = texture1,
+            px = 71,
+            py = 95,
+            atlas_table = 'ASSET_ATLAS',
+            prefix_config = {
 				key = false
 			}
-		}
-		SMODS.Atlas {
-			key = id .. "_2",
-			path = texture2,
-			px = 71,
-			py = 95,
-			atlas_table = 'ASSET_ATLAS',
-			prefix_config = {
+        }
+        SMODS.Atlas {
+            key = id .. "_2",
+            path = texture2,
+            px = 71,
+            py = 95,
+            atlas_table = 'ASSET_ATLAS',
+            prefix_config = {
 				key = false
 			}
-		}
-	end
+        }
+    end
 end
 
 ----------------------------

--- a/DSPlus.lua
+++ b/DSPlus.lua
@@ -16,21 +16,21 @@ local usable_path = mod_path:match("Mods/[^/]+")
 sendDebugMessage("Mod Path: " .. usable_path)
 
 function recursiveEnumerate(folder)
-    local fileTree = ""
-    for _, file in ipairs(love.filesystem.getDirectoryItems(folder)) do
-        local path = folder .. "/" .. file
-        local info = love.filesystem.getInfo(path)
-        fileTree = fileTree .. "\n" .. path .. (info.type == "directory" and " (DIR)" or "")
-        if info.type == "directory" then
-            fileTree = fileTree .. recursiveEnumerate(path)
-        end
-    end
-    return fileTree
+	local fileTree = ""
+	for _, file in ipairs(love.filesystem.getDirectoryItems(folder)) do
+		local path = folder .. "/" .. file
+		local info = love.filesystem.getInfo(path)
+		fileTree = fileTree .. "\n" .. path .. (info.type == "directory" and " (DIR)" or "")
+		if info.type == "directory" then
+			fileTree = fileTree .. recursiveEnumerate(path)
+		end
+	end
+	return fileTree
 end
 
 local files = {}
 for s in recursiveEnumerate(usable_path .. "/skins"):gmatch("[^\r\n]+") do
-    files[#files + 1] = s:gsub(usable_path .. "/skins/", "")
+	files[#files + 1] = s:gsub(usable_path .. "/skins/", "")
 end
 sendDebugMessage(tprint(files))
 
@@ -38,10 +38,10 @@ sendDebugMessage(tprint(files))
 --- Load Skins ---
 ------------------
 local loadCounts = {
-    Hearts = 0,
-    Clubs = 0,
-    Diamonds = 0,
-    Spades = 0
+	Hearts = 0,
+	Clubs = 0,
+	Diamonds = 0,
+	Spades = 0
 }
 
 local suits = {
@@ -53,15 +53,15 @@ local suits = {
 
 G.EXTRA_SKINS, G.EXTRA_SKINS_NAMES = {}, {}
 for suit in pairs(suits) do
-    G.EXTRA_SKINS[suit], G.EXTRA_SKINS_NAMES[suit] = {}, {}
+	G.EXTRA_SKINS[suit], G.EXTRA_SKINS_NAMES[suit] = {}, {}
 end
 
 local function suitMatches(skinSuit, suitAliases)
-    for _, alias in ipairs(suitAliases) do
-        if skinSuit:lower() == alias:lower() then
-            return true
-        end
-    end
+	for _, alias in ipairs(suitAliases) do
+		if skinSuit:lower() == alias:lower() then
+			return true
+		end
+	end
 end
 
 local function getSkinName(skin, suit)
@@ -78,7 +78,6 @@ local function getSkinName(skin, suit)
 		end
 	end
 end
-
 
 local function loadSkin(skin, id, suit, cards)
 	local skinName = getSkinName(skin, suit)
@@ -97,56 +96,61 @@ local function loadSkin(skin, id, suit, cards)
 end
 
 for _, file in ipairs(files) do
-    sendDebugMessage(file .. " found!")
+	sendDebugMessage(file .. " found!")
 
-    if file:match("%.lua$") then
-        local skin = SMODS.load_file("skins/" .. file)()
-        local id = file:sub(1, -5)
+	if file:match("%.lua$") then
+		local skin = SMODS.load_file("skins/" .. file)()
+		local id = file:sub(1, -5)
 
-        sendDebugMessage(file .. " loaded as " .. id)
+		sendDebugMessage(file .. " loaded as " .. id)
 
-        local defaultCards = { "2", "3", "4", "5", "6", "7", "8", "9", "10", "Jack", "Queen", "King", "Ace" }
-        local cardShorts = { J = "Jack", Q = "Queen", K = "King", A = "Ace" }
+		local defaultCards = {"2", "3", "4", "5", "6", "7", "8", "9", "10", "Jack", "Queen", "King", "Ace"}
+		local cardShorts = {
+			J = "Jack",
+			Q = "Queen",
+			K = "King",
+			A = "Ace"
+		}
 
-        local cards = skin.cards or defaultCards
-        for i, card in ipairs(cards) do
-            local normalized = card:lower():gsub("^%l", string.upper)
-            cards[i] = cardShorts[card:sub(1, 1)] or normalized
-        end
+		local cards = skin.cards or defaultCards
+		for i, card in ipairs(cards) do
+			local normalized = card:lower():gsub("^%l", string.upper)
+			cards[i] = cardShorts[card:sub(1, 1)] or normalized
+		end
 
-        local allSuits = skin.suit:lower() == "all" or skin.suit:lower() == "a" or skin.suit == "*"
-        for suit, aliases in pairs(suits) do
-            if allSuits or suitMatches(skin.suit, aliases) then
-                local loaded = loadSkin(skin, id, suit, cards)
+		local allSuits = skin.suit:lower() == "all" or skin.suit:lower() == "a" or skin.suit == "*"
+		for suit, aliases in pairs(suits) do
+			if allSuits or suitMatches(skin.suit, aliases) then
+				local loaded = loadSkin(skin, id, suit, cards)
 
 				if loaded and allSuits then
 					G.COLLABS.options[suit][id].ALL_SUITS = true
 				end
-            end
-        end
+			end
+		end
 
-        local texture1, texture2 = skin.texture, skin.highContrastTexture or skin.texture
-        SMODS.Atlas {
-            key = id .. "_1",
-            path = texture1,
-            px = 71,
-            py = 95,
-            atlas_table = 'ASSET_ATLAS',
-            prefix_config = {
+		local texture1, texture2 = skin.texture, skin.highContrastTexture or skin.texture
+		SMODS.Atlas {
+			key = id .. "_1",
+			path = texture1,
+			px = 71,
+			py = 95,
+			atlas_table = 'ASSET_ATLAS',
+			prefix_config = {
 				key = false
 			}
-        }
-        SMODS.Atlas {
-            key = id .. "_2",
-            path = texture2,
-            px = 71,
-            py = 95,
-            atlas_table = 'ASSET_ATLAS',
-            prefix_config = {
+		}
+		SMODS.Atlas {
+			key = id .. "_2",
+			path = texture2,
+			px = 71,
+			py = 95,
+			atlas_table = 'ASSET_ATLAS',
+			prefix_config = {
 				key = false
 			}
-        }
-    end
+		}
+	end
 end
 
 ----------------------------

--- a/DSPlus.lua
+++ b/DSPlus.lua
@@ -83,7 +83,7 @@ end
 local function loadSkin(skin, id, suit, cards)
 	local skinName = getSkinName(skin, suit)
 	if not skinName then
-		return
+		return false
 	end
 
 	G.COLLABS.options[suit][id] = cards
@@ -92,6 +92,8 @@ local function loadSkin(skin, id, suit, cards)
 	G.EXTRA_SKINS[suit][loadCounts[suit]] = id
 	G.EXTRA_SKINS_NAMES[suit][loadCounts[suit]] = skinName
 	sendDebugMessage(tprint(G.EXTRA_SKINS_NAMES[suit]))
+
+	return true
 end
 
 for _, file in ipairs(files) do
@@ -115,9 +117,9 @@ for _, file in ipairs(files) do
         local allSuits = skin.suit:lower() == "all" or skin.suit:lower() == "a" or skin.suit == "*"
         for suit, aliases in pairs(suits) do
             if allSuits or suitMatches(skin.suit, aliases) then
-                loadSkin(skin, id, suit, cards)
+                local loaded = loadSkin(skin, id, suit, cards)
 
-				if allSuits then
+				if loaded and allSuits then
 					G.COLLABS.options[suit][id].ALL_SUITS = true
 				end
             end


### PR DESCRIPTION
`skin.name` can now be either a `string` or a `table`. 

If `skin.name` is a string, the same name will be applied to all suits (`Hearts`, `Clubs`, `Diamonds`, `Spades`).

If `skin.name` is a table, each suit should have its own specified name. The skin will **not** be loaded for a suit if its name is missing from the table.

When specifying `skin.name` as a table, the keys must follow the same aliases as the `suit` field. This includes:
- Canonical suit names (`Hearts`, `Clubs`, `Diamonds`, `Spades`)
- Lowercase variations (`hearts`, `clubs`, `diamonds`, `spades`)
- Single-letter aliases (`H`, `C`, `D`, `S`)
- Lowercase single-letter aliases (`h`, `c`, `d`, `s`)

If a name for a suit is missing, the skin will not be loaded for that suit.

### Example

```lua
local skin = {
	suit = "*",  -- Applies to all suits
	name = {
		Hearts = 'example-Hearts',  -- Name for Hearts
		clubs = 'example-clubs',    -- Name for Clubs (lowercase alias)
		D = 'example-D',            -- Name for Diamonds (single-letter alias)
		s = 'example-s'             -- Name for Spades (lowercase single-letter alias)
	},
	texture = "example.png",
	highContrastTexture = nil,
	cards = nil
}

return skin
```
